### PR TITLE
Refine 'zsh-completion', fix typos

### DIFF
--- a/common/zsh-completion
+++ b/common/zsh-completion
@@ -1,10 +1,10 @@
-#compdef asd profile-sync-daemon
+#compdef asd anything-sync-daemon
 
 _asd() {
   local -a options
 
   options=('p:Preview what asd will do/is doing and printout useful info'
-           'c:Clean (delete without prompting) ALL crashrecovery dirs for all profiles')
+           'c:Clean (delete without prompting) ALL crashrecovery dirs for all sync targets')
 
   _describe 'options' options
 }


### PR DESCRIPTION
Hello, @graysky2 ! :smiley: 

Appreciates your great work!

This pull request fixes typos in file [zsh-completion](https://github.com/graysky2/anything-sync-daemon/blob/master/common/zsh-completion) which is imported from https://github.com/graysky2/profile-sync-daemon/pull/106 .

For the same reason in https://github.com/graysky2/anything-sync-daemon/pull/17 .

All the best wishes for you! :heart_decoration: 