### PR TITLE
Use --no-target-directory with mv 

### DIFF
--- a/common/anything-sync-daemon.in
+++ b/common/anything-sync-daemon.in
@@ -217,7 +217,7 @@ ungraceful_state_check() {
 						cp $opts "$TARGETTOKEEP" "$BACKUP-crashrecovery-$NOW"
 					fi
 
-					mv "$TARGETTOKEEP" "$DIR"
+					mv --no-target-directory "$TARGETTOKEEP" "$DIR"
 					rm -rf "$BACKUP"
 				else
 					# we only find the BACKUP and no BACKOVFS then either the initial resync
@@ -227,7 +227,7 @@ ungraceful_state_check() {
 					if [[ $CRRE -eq 1 ]]; then
 						opts="-a --reflink=auto"
 						cp $opts "$BACKUP" "$BACKUP-crashrecovery-$NOW"
-						mv "$BACKUP" "$DIR"
+						mv --no-target-directory "$BACKUP" "$DIR"
 					fi
 				fi
 			fi
@@ -303,7 +303,7 @@ do_sync() {
 
 			# backup target and link to tmpfs container
 			if [[ $(readlink "$DIR") != "$TMP" ]]; then
-				mv "$DIR" "$BACKUP"
+				mv --no-target-directory "$DIR" "$BACKUP"
 				ln -s "$TMP" "$DIR"
 				chown -h "$USER":"$GROUP" "$DIR"
 			fi
@@ -354,7 +354,7 @@ do_unsync() {
 			# updated so be sure to invoke a sync before an unsync
 
 			# restore original dirtree
-			[[ -d "$BACKUP" ]] && mv "$BACKUP" "$DIR"
+			[[ -d "$BACKUP" ]] && mv --no-target-directory "$BACKUP" "$DIR"
 			if [[ $OLFS -eq 1 ]] && mountpoint -q "$TMP"; then
 				rsync -aogX --delete-after --inplace --no-whole-file --exclude .flagged "$BACK_OVFS/" "$DIR/"
 				umount -l "$TMP"


### PR DESCRIPTION
To make sure we don't move the backup or target inside another directory.  This could happen if a parallel process creates the directory.