### PR TITLE
Autofix trailing slashes

### DIFF
--- a/common/anything-sync-daemon.in
+++ b/common/anything-sync-daemon.in
@@ -43,6 +43,20 @@ if [[ -f "${DAEMON_FILE}.conf" ]]; then
 	. "$ASDCONF"
 fi
 
+# saving current extended pattern matching setting
+previous_extglob_setting=$(shopt -p extglob)
+
+# ensuring pattern matching is enabled
+shopt -s extglob
+
+# removing any trailing slash(es) from the list of directories to sync
+WHATTOSYNC=("${WHATTOSYNC[@]%%+(/)}")
+
+# setting everything back
+$previous_extglob_setting
+unset previous_extglob_setting
+
+
 [[ -z "$VOLATILE" ]] && VOLATILE=/tmp
 
 # simple function to determine user intent rather than using a null value
@@ -145,14 +159,6 @@ config_check() {
 				echo -e "${BLD}Edit ${BLU}$ASDCONF${NRM}${BLD} correcting the mistake and try again."${NRM}
 				exit 1
 			fi
-		fi
-		
-		# no trailing slashes are allowed
-		if [[ "${DIR: -1}" = "/" ]]; then
-			echo -e "${BLD}Trailing slash in your WHATTOSYNC array detected:"${NRM}
-			echo -e " ${BLD}${RED}$DIR"${NRM}
-			echo -e "${BLD}Edit ${BLU}$ASDCONF${NRM}${BLD} removing the trailing slash and try again."${NRM}
-			exit 1
 		fi
 	done
 }

--- a/common/anything-sync-daemon.in
+++ b/common/anything-sync-daemon.in
@@ -51,6 +51,7 @@ shopt -s extglob
 
 # removing any trailing slash(es) from the list of directories to sync
 WHATTOSYNC=("${WHATTOSYNC[@]%%+(/)}")
+VOLATILE="${VOLATILE%%+(/)}"
 
 # setting everything back
 $previous_extglob_setting

--- a/common/asd.conf
+++ b/common/asd.conf
@@ -28,7 +28,6 @@ WHATTOSYNC=()
 # Note that using a value of '/dev/shm' can cause problems with systemd's
 # NAMESPACE spawning only when users enable the overlayfs option.
 #
-# Use NO trailing slash!
 #VOLATILE="/tmp"
 
 # Uncomment and set to yes to use an overlayfs instead of a full copy to reduce

--- a/common/asd.conf
+++ b/common/asd.conf
@@ -9,8 +9,7 @@
 ## you start-up asd.
 
 # Define the target(s) directories in the WHATTOSYNC array.
-# Do NOT define a file! These MUST be directories with an absolute path
-# and must not end in a trailing slash.
+# Do NOT define a file! These MUST be directories with an absolute path.
 #
 # Note that the target DIRECTORIES and all subdirs under them will be included.
 # In other words, this is recursive.

--- a/doc/asd.1
+++ b/doc/asd.1
@@ -48,8 +48,6 @@ Example:
  '/foo/bar'
  )
 
- Note that there are no trailing slashes for entries in the WHATTOSYNC array.
-
 .fam T
 .fi
 .SH RUNNING ASD


### PR DESCRIPTION
Added shell parameter expansion to remove every trailing slashes in the parameters loaded from asd.conf, fixing issue #42. This includes all entries of the WHATTOSYNC array, as well as the VOLATILE variable.

Updated asd.conf template and man page accordingly.

The shell parameter expansion uses an extended pattern matching which requires the shell option extglob to be set. I made sure this doesn't (and won't in the future) interfere with the rest of the script, but maybe it could be set for entirety of the script. 