### PR TITLE
Return non-zero exit code breaks first call of systemd unit

### DIFF
--- a/common/anything-sync-daemon.in
+++ b/common/anything-sync-daemon.in
@@ -76,7 +76,7 @@ unset previous_extglob_setting
 # bail if $VOLATILE isn't tmpfs
 df -T "$VOLATILE" | grep -m 1 -q tmpfs || {
 echo "$VOLATILE is not tmpsfs so running asd is pointless. Aborting." >&2
-exit 1; }
+exit 0; }
 
 # simple function to determine user intent rather than using a null value
 case "${USE_OVERLAYFS,,}" in
@@ -163,7 +163,7 @@ config_check() {
   # nothing to do if these are empty
   if [[ -z "${WHATTOSYNC[0]}" ]]; then
     echo -e " ${BLD}Must define at least one directory in ${NRM}${BLU}$ASDCONF${NRM}"
-    exit 1
+    exit 0
   fi
 
   # make sure the user defined real dirs


### PR DESCRIPTION
When installing the anything-sync-daemon and run  "systemctl start"
before adjust asd.conf, the systemd unit returns it is failed.
This is caused by the return of a non-zero exit code if no directory
to sync is set or the $VOLATILE is not adjusted yet.

This commit sets a zero exit code for this not uncommon cases so the
call of the "systemctl start" does not fail but just stop due to the
exit command.

This is necessary since so package manager like dpkg can try to start
the systemd unit after installation/upgrade and do not fail due to a
failure of the systemd unit.