### PR TITLE
Allow using zram based device

### DIFF
--- a/common/anything-sync-daemon.in
+++ b/common/anything-sync-daemon.in
@@ -74,7 +74,7 @@ unset previous_extglob_setting
 [[ -z "$VOLATILE" ]] && VOLATILE=/tmp
 
 # bail if $VOLATILE isn't tmpfs
-df -T "$VOLATILE" | grep -m 1 -q tmpfs || {
+df -T "$VOLATILE" | grep -m 1 -q '\( tmpfs \|^/dev/zram\)' || {
 echo "$VOLATILE is not tmpsfs so running asd is pointless. Aborting." >&2
 exit 1; }
 


### PR DESCRIPTION
Update bail filter to allow using Zram devices, which are not tmpfs. Also, better filtering of tmpfs, to be sure the grep does not match for path like /path/to/fake/tmpfs mounted.