### PR TITLE
Adds Open RC Support to ASD

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -34,7 +34,8 @@ BUILDING
 
  For OpenRC-based systems, use the supplied OpenRC init script and the
  hourly cronjob for periodic resyncs, since timer-driven alternatives are
- not available by default.
+ not available by default. WARNING: you may have to move the cron script 
+ to a different location depending on which cron service you are using 
 
 USE A DISTRO PROVIDED PACKAGE
  ARCH LINUX

--- a/INSTALL
+++ b/INSTALL
@@ -1,12 +1,13 @@
 DEPENDENCIES
  bash >=4.0
- cron (only if using upstart)
+ cron (only if using upstart or OpenRC)
  find
  rsync
 
  a supported init system
  -systemd
  -upstart
+ -OpenRC
 
 WARNING
 To avoid data loss, it is HIGHLY recommended that users stop any running
@@ -24,11 +25,16 @@ BUILDING
 
   # make install-systemd-all
   # make install-upstart-all
+  # make install-openrc-all
 
  As of v3.13, the Makefiles for systemd-native distros such as Arch, Exherbo,
  and Fedora, no longer install the deprecated cron script using a systemd
  timer instead. Users may override and install the deprecated cron script by
- running make with `install-with-cron` instead  of `install` at this point.
+ running make with `install-with-cron` instead of `install` at this point.
+
+ For OpenRC-based systems, use the supplied OpenRC init script and the
+ hourly cronjob for periodic resyncs, since timer-driven alternatives are
+ not available by default.
 
 USE A DISTRO PROVIDED PACKAGE
  ARCH LINUX

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CONFDIR = /etc
 CRONDIR = /etc/cron.hourly
 INITDIR_SYSTEMD = /usr/lib/systemd/system
 INITDIR_UPSTART = /etc/init.d
+INITDIR_OPENRC = /etc/init.d
 BINDIR = $(PREFIX)/bin
 DOCDIR = $(PREFIX)/share/doc/$(PN)
 MANDIR = $(PREFIX)/share/man/man1
@@ -82,15 +83,23 @@ install-upstart:
 	$(INSTALL_DIR) "$(DESTDIR)$(INITDIR_UPSTART)"
 	$(INSTALL_SCRIPT) init/asd.upstart "$(DESTDIR)$(INITDIR_UPSTART)/asd"
 
+install-openrc:
+	$(Q)echo -e '\033[1;32mInstalling OpenRC files...\033[0m'
+	$(INSTALL_DIR) "$(DESTDIR)$(CONFDIR)"
+	$(INSTALL_DIR) "$(DESTDIR)$(INITDIR_OPENRC)"
+	$(INSTALL_SCRIPT) init/asd.openrc "$(DESTDIR)$(INITDIR_OPENRC)/asd"
 
 install-systemd-all: install-bin install-man install-systemd
 
 install-upstart-all: install-bin install-man install-cron install-upstart
 
+install-openrc-all: install-bin install-man install-cron install-openrc
+
 install:
 	$(Q)echo "run one of the following:"
 	$(Q)echo "  make install-systemd-all (systemd based systems)"
 	$(Q)echo "  make install-upstart-all (upstart based systems)"
+	$(Q)echo "  make install-openrc-all (OpenRC based systems)"
 	$(Q)echo
 	$(Q)echo "or check out the Makefile for specific rules"
 
@@ -119,18 +128,23 @@ uninstall-upstart:
 	$(RM) "$(DESTDIR)$(CONFDIR)/asd.conf"
 	$(RM) "$(DESTDIR)$(INITDIR_UPSTART)/asd"
 
+uninstall-openrc:
+	$(RM) "$(DESTDIR)$(INITDIR_OPENRC)/asd"
+
 uninstall-systemd-all: uninstall-bin uninstall-man uninstall-systemd
 
 uninstall-upstart-all: uninstall-bin uninstall-man uninstall-cron uninstall-upstart
+uninstall-openrc-all: uninstall-bin uninstall-man uninstall-cron uninstall-openrc
 
 uninstall:
 	$(Q)echo "run one of the following:"
 	$(Q)echo "  make uninstall-systemd-all (systemd based systems)"
 	$(Q)echo "  make uninstall-upstart-all (upstart based systems)"
+	$(Q)echo "  make uninstall-openrc-all (OpenRC based systems)"
 	$(Q)echo
 	$(Q)echo "or check out the Makefile for specific rules"
 
 clean:
 	$(RM) -f common/$(PN)
 
-.PHONY: help install-bin install-man install-cron install-systemd install-upstart install-systemd-all install-upstart-all install uninstall-bin uninstall-man uninstall-cron uninstall-systemd uninstall-upstart uninstall-systemd-all uninstall clean
+.PHONY: help install-bin install-man install-cron install-systemd install-upstart install-openrc install-systemd-all install-upstart-all install-openrc-all install uninstall-bin uninstall-man uninstall-cron uninstall-systemd uninstall-upstart uninstall-openrc uninstall-systemd-all uninstall-upstart-all uninstall-openrc-all uninstall clean

--- a/README.md
+++ b/README.md
@@ -7,5 +7,8 @@ Consult the man page or the wiki page: https://wiki.archlinux.org/index.php/Anyt
 ## Installation from Source
 To build from source, see the included INSTALL text document.
 
+For OpenRC-based systems, use `make install-openrc-all` to install the OpenRC
+service script and the hourly cron job for periodic resync.
+
 ## Installation from Distro Packages
 * ![logo](http://www.monitorix.org/imgs/archlinux.png "arch logo")Arch: in the [AUR](https://aur.archlinux.org/packages/anything-sync-daemon).

--- a/doc/asd.1
+++ b/doc/asd.1
@@ -127,7 +127,9 @@ For distros not using systemd, another init script should be used to manage the 
 .PP
 On OpenRC systems, install the OpenRC init script and use the hourly cron script
 installed to /etc/cron.hourly to perform periodic resyncs. The target system must
-have cron installed and active for this to happen.
+have cron installed and active for this to happen. WARNING: you may have to put the cron.hourly script 
+in a different location or change your crontab configuration depending on the implementation of cron you are using
+For instance BusyBox crond has their periodic hourly scripts loaded to /etc/periodic/hourly
 .PP
 Example OpenRC commands:
 .nf

--- a/doc/asd.1
+++ b/doc/asd.1
@@ -123,9 +123,19 @@ stop
 enable
 disable
 .SS  START AND STOP ASD FOR USERS OF OTHER INIT SYSTEMS
-For distros not using systemd, another init script should be used to manage the daemon. Examples are provided and are known to work with Upstart.
+For distros not using systemd, another init script should be used to manage the daemon. Examples are provided and are known to work with Upstart and OpenRC.
 .PP
-Note that for these init systems, the supplied cron script (installed to /etc/cron.hourly) will run the resync option to keep the tmpfs copies sync'ed. Of course, the target system must have cron installed and active for this to happen.
+On OpenRC systems, install the OpenRC init script and use the hourly cron script
+installed to /etc/cron.hourly to perform periodic resyncs. The target system must
+have cron installed and active for this to happen.
+.PP
+Example OpenRC commands:
+.nf
+ # rc-service asd start
+ # rc-service asd stop
+ # rc-service asd status
+ # rc-update add asd default
+.fi
 .SH SUPPORTED DISTROS
 At this time, the following distros are officially supported but there is no reason to think that asd will not run on another distro:
 .IP \(bu 3

--- a/init/asd.openrc
+++ b/init/asd.openrc
@@ -1,0 +1,32 @@
+#!/sbin/openrc-run
+
+# Anything-sync-daemon OpenRC service
+# This service uses the daemon's own sync/unsync commands and tracks
+# the active state by the daemon lock file.
+
+description="Anything-sync-daemon"
+
+depend() {
+    need localmount
+    before shutdown
+}
+
+start() {
+    ebegin "Starting Anything-sync-daemon"
+    /usr/bin/anything-sync-daemon sync
+    eend $?
+}
+
+stop() {
+    ebegin "Stopping Anything-sync-daemon"
+    /usr/bin/anything-sync-daemon unsync
+    eend $?
+}
+
+status() {
+    if [ -f /run/asd ]; then
+        eend 0
+    else
+        eend 1
+    fi
+}


### PR DESCRIPTION
### Summary
1) Adds Open RC support to ASD
2) Updates made to  docs and Makefile/Install  script to support Open RC

### Testing Detail
1) Tested on Alpine Linux V3.23.4 with kernel 6.12.85-0-rpi
2) Followed Updated instructions

### Testing Outputs
``` raspi5:~$ sudo asd parse
Waiting for lock...
flock: getting lock took 0.000003 seconds
flock: executing /usr/bin/asd
Anything-sync-daemon v6.0.0 on Alpine Linux v3.23

 Daemon pid file is present.
 Resync cronjob is present.
 Overlayfs v23 is currently active.

Asd will manage the following per /run/asd.conf settings:

 owner/group id:     root/0
 target to manage:   /home/user/docker/homeassistant/config
 sync target:        /home/user/docker/homeassistant/.config-backup_asd
 tmpfs target:       /tmp/asd-root/home/user/docker/homeassistant/config
 dir size:           502M
 overlayfs size:     68M
 recovery dirs:      none

 owner/group id:     root/0
 target to manage:   /home/user/docker/homeassistant/config-mosquitto
 sync target:        /home/user/docker/homeassistant/.config-mosquitto-backup_asd
 tmpfs target:       /tmp/asd-root/home/user/docker/homeassistant/config-mosquitto
 dir size:           328K
 overlayfs size:     328K
 recovery dirs:      none

 owner/group id:     root/0
 target to manage:   /home/user/docker/homeassistant/zigbee2mqtt-data
 sync target:        /home/user/docker/homeassistant/.zigbee2mqtt-data-backup_asd
 tmpfs target:       /tmp/asd-root/home/user/docker/homeassistant/zigbee2mqtt-data
 dir size:           64K
 overlayfs size:     12K
 recovery dirs:      none

 owner/group id:     root/0
 target to manage:   /home/user/docker/homeassistant/zwave-config
 sync target:        /home/user/docker/homeassistant/.zwave-config-backup_asd
 tmpfs target:       /tmp/asd-root/home/user/docker/homeassistant/zwave-config
 dir size:           37M
 overlayfs size:     552K
 recovery dirs:      none

 owner/group id:     root/0
 target to manage:   /home/user/AdGuardHome/data
 sync target:        /home/user/AdGuardHome/.data-backup_asd
 tmpfs target:       /tmp/asd-root/home/user/AdGuardHome/data
 dir size:           28M
 overlayfs size:     0
 recovery dirs:      none

```
```
sudo asd resync
Waiting for lock...
flock: getting lock took 0.000003 seconds
flock: executing /usr/bin/asd
+ rsync -aX --delete-after --exclude .flagged /tmp/asd-root/home/user/docker/homeassistant/config/ /home/user/docker/homeassistant/.config-backup_asd/ --info=progress2
     69,925,248  13%   57.17MB/s    0:00:01 (xfr#2, to-chk=0/4818)   
+ set +x
+ rsync -aX --delete-after --exclude .flagged /tmp/asd-root/home/user/docker/homeassistant/config-mosquitto/ /home/user/docker/homeassistant/.config-mosquitto-backup_asd/ --info=progress2
              0   0%    0.00kB/s    0:00:00 (xfr#0, to-chk=0/8)
+ set +x
+ rsync -aX --delete-after --exclude .flagged /tmp/asd-root/home/user/docker/homeassistant/zigbee2mqtt-data/ /home/user/docker/homeassistant/.zigbee2mqtt-data-backup_asd/ --info=progress2
          7,654  77%    2.36MB/s    0:00:00 (xfr#2, to-chk=0/27) 
+ set +x
+ rsync -aX --delete-after --exclude .flagged /tmp/asd-root/home/user/docker/homeassistant/zwave-config/ /home/user/docker/homeassistant/.zwave-config-backup_asd/ --info=progress2
        216,762   0%   21.93MB/s    0:00:00 (xfr#2, to-chk=0/2820)   
+ set +x
+ rsync -aX --delete-after --exclude .flagged /tmp/asd-root/home/user/AdGuardHome/data/ /home/user/AdGuardHome/.data-backup_asd/ --info=progress2
              0   0%    0.00kB/s    0:00:00 (xfr#0, to-chk=0/20)
+ set +x
Sync successful
```